### PR TITLE
Change healthchecks to point to /-/healthy /-/ready

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -60,16 +60,16 @@ spec:
               containerPort: {{ .Values.ports.http }}
           livenessProbe:
             httpGet:
-              path: /api/v1/status/config
+              path: /-/healthy
               port: {{ .Values.ports.http }}
-            initialDelaySeconds: 90
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 5
           readinessProbe:
             httpGet:
-              path: /api/v1/status/config
+              path: /-/ready
               port: {{ .Values.ports.http }}
-            initialDelaySeconds: 90
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 5
       volumes:
         - name: prometheus-config-volume
           configMap:


### PR DESCRIPTION
This PR 
- updates the endpoints to point t /healthy and /ready
- reduces initial delay and period
- allows prometheus to come up in <45 seconds in a clean install
- similar results when rebooting only the prometheus pod