### PR TITLE
Update charts for worker and scheduler to switch based on `persistence` var

### DIFF
--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -2,6 +2,7 @@
 ## Airflow Scheduler Deployment/StatefulSet
 #################################
 {{- $local := or (eq .Values.executor "LocalExecutor") (eq .Values.executor "SequentialExecutor") }}
+{{- $persistence := .Values.workers.persistence.enabled }}
 kind: {{ if $local }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
 metadata:
@@ -85,19 +86,18 @@ spec:
           env:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
+        {{- if $persistence }}
         - name: {{ .Release.Name }}-worker-gc
           image: {{ template "airflow_image" . }}
           args: ["crond", "-f", "-d", "0"]
-          volumeMounts:
-            - name: logs
-              mountPath: {{ template "airflow_logs" . }}
+        {{- end }}
       {{- end }}
 {{- if not $local }}
       volumes:
         - name: logs
           emptyDir: {}
           sizeLimit: {{ .Values.workers.persistence.size }}
-{{- else }}
+{{- else if $persistence }}
   volumeClaimTemplates:
     - metadata:
         name: logs

--- a/charts/airflow/templates/workers/worker-deployment.yaml
+++ b/charts/airflow/templates/workers/worker-deployment.yaml
@@ -1,8 +1,9 @@
 ################################
-## Airflow Worker StatefulSet
+## Airflow Worker Deployment
 #################################
+{{- $persistence := .Values.workers.persistence.enabled }}
 {{- if eq .Values.executor "CeleryExecutor" }}
-kind: StatefulSet
+kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-worker
@@ -17,7 +18,6 @@ metadata:
 spec:
   serviceName: {{ .Release.Name }}-worker
   replicas: {{ .Values.workers.replicas }}
-  podManagementPolicy: Parallel
   selector:
     matchLabels:
       tier: airflow
@@ -58,12 +58,10 @@ spec:
           ports:
             - name: worker-logs
               containerPort: {{ .Values.ports.workerLogs }}
-          volumeMounts:
-            - name: logs
-              mountPath: {{ template "airflow_logs" . }}
           env:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
+{{- if $persistence }}
         - name: {{ .Release.Name }}-worker-gc
           image: {{ template "airflow_image" . }}
           args: ["crond", "-f", "-d", "0"]
@@ -72,7 +70,8 @@ spec:
           volumeMounts:
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
-{{- if not .Values.workers.persistence.enabled }}
+{{- end }}
+{{- if not $persistence }}
       volumes:
         - name: logs
           emptyDir: {}


### PR DESCRIPTION
Workers will switch to deployments if the `persistence` flag is set to False, otherwise they will be deployed as stateful sets.

Scheduler chart change- mounts the log volumes to the scheduler if the persistence var is True, otherwise uses emptyDir