### PR TITLE
Increase readinessProbe.failureThreshold

### DIFF
--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -71,7 +71,7 @@ spec:
               port: {{ .Values.ports.airflowUI }}
             initialDelaySeconds: {{ .Values.webserver.initialDelaySeconds | default 10 }}
             timeoutSeconds: {{ .Values.webserver.timeoutSeconds | default 30 }}
-            failureThreshold: {{ .Values.webserver.failureThreshold | default 10 }}
+            failureThreshold: {{ .Values.webserver.failureThreshold | default 30 }}
             periodSeconds: {{ .Values.webserver.periodSeconds | default 5 }}
           env:
           {{- include "custom_airflow_environment" . | indent 10 }}


### PR DESCRIPTION
We have seen multiple customers in the past two weeks get their web server stuck in a crash loop because it takes too long for their webserver to spin up, crossing the `failureThreshold` and causing it to restart.

Without any changes to resources, increasing the `failureThreshold` from 10 to 30 solves this.