### PR TITLE
Configure Airflow Webserver to use RBAC+Astro's FAB SecurityManager

### DIFF
--- a/charts/airflow/templates/_helpers.yaml
+++ b/charts/airflow/templates/_helpers.yaml
@@ -166,6 +166,10 @@ max_client_conn = {{ .Values.pgbouncer.maxClientConn }}
 {{ define "airflow_config_path" -}}
 {{ (printf "%s/airflow.cfg" .Values.airflowHome) | quote }}
 {{- end }}
+{{ define "airflow_webserver_config_path" -}}
+{{ (printf "%s/webserver_config.py" .Values.airflowHome) | quote }}
+{{- end }}
+
 
 {{ define "airflow_config" -}}
 {{ (printf "%s-airflow-config" .Release.Name) }}

--- a/charts/airflow/templates/configmap.yaml
+++ b/charts/airflow/templates/configmap.yaml
@@ -26,6 +26,7 @@ data:
     [webserver]
     base_url = {{ printf "https://%s" (include "airflow_url" .) }}
     expose_config = True
+    rbac = True
 
     [celery]
     default_queue = celery
@@ -63,3 +64,27 @@ data:
     release = {{ .Release.Name }}
     platform = {{ .Values.platform.release }}
     workspace = {{ .Values.platform.workspace }}
+
+    [astronomer]
+    jwt_signing_cert = /etc/airflow/ssl/tls.crt
+    jwt_audience = {{ include "airflow_url" . }}
+
+  webserver_config.py: |
+    import os
+    from airflow import configuration as conf
+    from flask_appbuilder.security.manager import AUTH_REMOTE_USER
+    basedir = os.path.abspath(os.path.dirname(__file__))
+
+    # The SQLAlchemy connection string.
+    SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
+
+    # Flask-WTF flag for CSRF
+    CSRF_ENABLED = True
+
+    # ----------------------------------------------------
+    # AUTHENTICATION CONFIG
+    # ----------------------------------------------------
+    AUTH_TYPE = AUTH_REMOTE_USER
+
+    from astronomer.flask_appbuilder.security import AirflowAstroSecurityManager
+    SECURITY_MANAGER_CLASS = AirflowAstroSecurityManager

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -54,6 +54,14 @@ spec:
               mountPath: {{ template "airflow_config_path" . }}
               subPath: airflow.cfg
               readOnly: true
+            - name: config
+              mountPath: {{ template "airflow_webserver_config_path" . }}
+              subPath: webserver_config.py
+              readOnly: true
+            - name: signing-certificate
+              mountPath: /etc/airflow/ssl
+              subPath: tls.crt
+              readOnly: true
           ports:
             - name: webserver-ui
               containerPort: {{ .Values.ports.airflowUI }}
@@ -80,3 +88,6 @@ spec:
         - name: config
           configMap:
             name: {{ template "airflow_config" . }}
+        - name: signing-certificate
+          secret:
+            secretName: {{ .Values.global.tlsSecret }}


### PR DESCRIPTION
This allows  us to use the RBAC mode and have users auto-created and
managed from the JWT token that houston provides.

I haven't tested this change :( I'm not sure the best way of doing so?

This will also need an change in our Airflow image to install the fab-sec-manager (which I'm preparing now)

Part of astronomer/astronomer#244