### PR TITLE
Enable DELETE requests on registry.

### DIFF
--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -23,6 +23,8 @@ data:
         blobdescriptor: inmemory
       filesystem:
         rootdirectory: /var/lib/registry
+      delete:
+        enabled: true
     http:
       addr: :5000
       # debug:


### PR DESCRIPTION
The tokens we currently issue will not allow DELETE on any token, but
enable it at the registry level so that we can manually issue tokens to
delete images if we need to.