### PR TITLE
nginx support for a GKE Internal LB

### DIFF
--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -20,6 +20,7 @@ metadata:
     # This annotation is detected by EKS to indicate that
     # it should provision a private ("internal") load balancer
     service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    cloud.google.com/load-balancer-type: "Internal"
     {{- end }}
 
     # Metrics annotations


### PR DESCRIPTION
Added an annotation to create an internal load balancer for the nginx controller if the _privateLoadBalancer_ variable is selected.