### PR TITLE
Propagate the nginx LB IP to all monitored ingress resources

### DIFF
--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -46,6 +46,7 @@ spec:
             {{- if .Values.global.singleNamespace }}
             - --watch-namespace={{ .Release.Namespace }}
             {{- end }}
+            - --publish-service={{ .Release.Namespace }}/{{ template "nginx.fullname" . }}
           ports:
             - name: http
               containerPort: {{ .Values.ports.http }}


### PR DESCRIPTION
Added the _--publish-service_ cmd arg to the nginx-controller in order to update all monitored ingress resources with the IP address of the load balancer. 

This way, the ingress metadata is more consistent and could be used by services like _external-dns_ to create the mapping between an ingress hostname and the LB IP. In case of external-dns, this mapping could then be exported to dns providers such as Route53, CloudDNS, etc.