### PR TITLE
publish top-level helm chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
-name: astronomer
+name: "helm.astronomer.io"
 version: 0.9.1-alpha.4
 appVersion: 0.9.1-alpha.4
 description: Helm chart to deploy the Astronomer Platform

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ build: update-version
 	for chart in ${CHARTS} ; do \
 		helm package --version ${ASTRONOMER_VERSION} -d ${OUTPUT} charts/$${chart} || exit 1; \
 	done; \
+	helm package --version ${ASTRONOMER_VERSION} -d ${OUTPUT} . || exit 1; \
 	$(MAKE) build-index
 
 .PHONY: build-index
@@ -35,6 +36,7 @@ push-repo:
 	for chart in ${CHARTS} ; do \
 		gsutil cp -a public-read ${OUTPUT}/$${chart}-${ASTRONOMER_VERSION}.tgz ${BUCKET} || exit 1; \
 	done; \
+	gsutil cp -a public-read ${OUTPUT}/helm.astronomer.io-${ASTRONOMER_VERSION}.tgz ${BUCKET} || exit 1; \
 	$(MAKE) push-index
 
 .PHONY: push-index
@@ -46,6 +48,7 @@ clean:
 	for chart in ${CHARTS} ; do \
 		rm ${OUTPUT}/$${chart}-${ASTRONOMER_VERSION}.tgz || exit 1; \
 	done; \
+	rm ${OUTPUT}/helm.astronomer.io-${ASTRONOMER_VERSION}.tgz || exit 1; \
 
 .PHONY: update-image-tags
 update-image-tags: check-env

--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -16,6 +16,12 @@ metadata:
     # XXX: Currently NLB has issues in EKS
     # service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 
+    {{- if .Values.privateLoadBalancer }}
+    # This annotation is detected by EKS to indicate that
+    # it should provision a private ("internal") load balancer
+    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    {{- end }}
+
     # Metrics annotations
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.ports.metrics | quote }}

--- a/configs/starter.yaml
+++ b/configs/starter.yaml
@@ -18,3 +18,5 @@ global:
 nginx:
   # IP address the nginx ingress should bind to
   loadBalancerIP: ~
+  # set to 'true' when deploying to a private EKS cluster
+  privateLoadBalancer: false


### PR DESCRIPTION
this will enable us to helm release using the repository instead of git-cloning.