### PR TITLE
Run CI for monitoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  install-helm-tags:
     jobs:
       - platform
       - monitoring

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,26 @@
 version: 2
+
 jobs:
-  build:
+  install-platform:
     machine:
       image: ubuntu-1604:201903-01
     steps:
       - checkout
       - run:
-          name: Dry Run
-          command: bin/run-ci
+          name: Install Platform and Logging
+          command: bin/run-ci platform logging
+  install-monitoring:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Install Monitoring and Kubed
+          command: bin/run-ci monitoring kubed
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - install-platform
+      - install-monitoring

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,14 @@ jobs:
       - run:
           name: Monitoring
           command: bin/run-ci monitoring
-  logging:
-    machine:
-      image: ubuntu-1604:201903-01
-    steps:
-      - checkout
-      - run:
-          name: Logging
-          command: bin/run-ci logging
+  # logging:
+  #   machine:
+  #     image: ubuntu-1604:201903-01
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: Logging
+  #         command: bin/run-ci logging
   kubed:
     machine:
       image: ubuntu-1604:201903-01
@@ -40,5 +40,5 @@ workflows:
     jobs:
       - platform
       - monitoring
-      - logging
+      # - logging
       - kubed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,44 @@
 version: 2
 
 jobs:
-  install-platform:
+  platform:
     machine:
       image: ubuntu-1604:201903-01
     steps:
       - checkout
       - run:
-          name: Install Platform and Logging
-          command: bin/run-ci platform logging
-  install-monitoring:
+          name: Platform
+          command: bin/run-ci platform
+  monitoring:
     machine:
       image: ubuntu-1604:201903-01
     steps:
       - checkout
       - run:
-          name: Install Monitoring and Kubed
-          command: bin/run-ci monitoring kubed
+          name: Monitoring
+          command: bin/run-ci monitoring
+  logging:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Logging
+          command: bin/run-ci logging
+  kubed:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Kubed
+          command: bin/run-ci kubed
 
 workflows:
   version: 2
   build:
     jobs:
-      - install-platform
-      - install-monitoring
+      - platform
+      - monitoring
+      - logging
+      - kubed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Astronomer Platform Helm Charts
 
+[![CircleCI](https://circleci.com/gh/astronomer/helm.astronomer.io.svg?style=svg)](https://circleci.com/gh/astronomer/helm.astronomer.io)
+
 This repository contains the helm charts for deploying the [Astronomer Platform](https://github.com/astronomer/astronomer) into a Kubernetes cluster.
 
 Astronomer is a commercial "Airflow as a Service" platform that runs on Kubernetes. Source code is made available for the benefit of our customers, if you'd like to use the platform [reach out for a license](https://www.astronomer.io/enterprise/) or try out [Astronomer Cloud](https://www.astronomer.io/cloud/).

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -65,7 +65,11 @@ while [ $RC -eq 0 ]; do
       echo "kubectl get pods timed out. retrying."
       continue
     fi
-    cat /tmp/pods | grep -v 1/1 | grep -v NAME >/dev/null 2>&1
+    # Ignore elasticsearch-nginx in order to allow for testing the deployment
+    # of logging tag without the platform. This is the only logging component
+    # that will not start without the platform. The benefit of allowing us to
+    # test the logging tag outweighs the downside of ignoring one pod.
+    cat /tmp/pods | grep -v 1/1 | grep -v NAME | grep -v 'elasticsearch-nginx' >/dev/null 2>&1
     RC=$?
   fi
 done

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -56,7 +56,7 @@ while [ $RC -eq 0 ]; do
   echo "${DURATION} seconds have elapsed, timeout at 800 seconds"
   if [ $DURATION -gt 800 ];then
     HELM_CODE=1
-    RC=0
+    RC=1
     echo "Error (timeout): giving up after 800 seconds"
   else
     sleep 10

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -19,6 +19,15 @@ source $REPO_DIR/bin/setup-kind
 
 echo "Deploying Astronomer..."
 
+platform=false
+logging=false
+monitoring=false
+kubed=false
+for component in $@
+do
+  export $component=true
+done
+
 set +ex
 
 kubectl get pods -n astronomer -w &
@@ -30,10 +39,10 @@ helm install \
   --namespace astronomer \
   -n astronomer \
   -f configs/local-dev.yaml \
-  --set tags.platform=true \
-  --set tags.logging=false \
-  --set tags.monitoring=false \
-  --set tags.kubed=false \
+  --set tags.platform=${platform} \
+  --set tags.logging=${logging} \
+  --set tags.monitoring=${monitoring} \
+  --set tags.kubed=${kubed} \
   $REPO_DIR
 
 sleep 5

--- a/configs/local-dev.yaml
+++ b/configs/local-dev.yaml
@@ -21,8 +21,7 @@ global:
 
 ############################
 ## Astronomer configuration
-## Configure resouce requests
-## as small as possible
+## Omit resouce requests
 ############################
 
 astronomer:
@@ -31,15 +30,11 @@ astronomer:
       requests:
         cpu: "0m"
         memory: "0Mi"
-    limits:
-      cpu: "100m"
   houston:
     resources:
       requests:
         cpu: "0m"
         memory: "0Mi"
-      limits:
-        cpu: "500m"
 
     config:
       auth:
@@ -55,8 +50,6 @@ astronomer:
       requests:
         cpu: "0m"
         memory: "0Mi"
-      limits:
-        cpu: "100m"
   registry:
     resources:
       requests:
@@ -76,10 +69,10 @@ nginx:
   # Configure resources
   resources:
     requests:
-      cpu: "0m"
-      memory: "0Mi"
+      cpu: "500m"
+      memory: "1024Mi"
     limits:
-      cpu: "100m"
+      cpu: "1"
       memory: "2048Mi"
 
 #################################
@@ -91,8 +84,6 @@ grafana:
     requests:
       cpu: "0m"
       memory: "0Mi"
-    limits:
-      cpu: "100m"
 
 #################################
 ## Prometheus configuration
@@ -103,9 +94,6 @@ prometheus:
     requests:
       cpu: "0m"
       memory: "0Gi"
-    limits:
-      cpu: "100m"
-      memory: "2Gi"
 
 #################################
 ## Elasticsearch configuration
@@ -115,41 +103,26 @@ elasticsearch:
   client:
     replicas: 1
     resources:
-      heapMemory: 256
       requests:
         cpu: "0"
-        memory: "256Mi"
+        memory: "0Gi"
 
   # Configure data nodes
   data:
     replicas: 1
     resources:
-      heapMemory: 128
       requests:
         cpu: "0"
-        memory: "128Mi"
-      limits:
-        cpu: "100m"
-    persistence:
-      size: 1Gi
+        memory: "0"
 
   # Configure master nodes
   master:
     replicas: 1
     resources:
-      heapMemory: 128
       requests:
         cpu: "0"
-        memory: "128Mi"
-      limits:
-        cpu: "100m"
-    env:
-      NUMBER_OF_MASTERS: "1"
-    persistence:
-      size: 1Gi
+        memory: "0Gi"
 
-  curator:
-    enabled: false
 
 #################################
 ## Kibana configuration
@@ -160,8 +133,6 @@ kibana:
     requests:
       cpu: "0m"
       memory: "0Mi"
-    limits:
-      cpu: "100m"
 
 
 #################################
@@ -173,8 +144,7 @@ fluentd:
     requests:
       cpu: "0m"
       memory: "0Mi"
-    limits:
-      cpu: "100m"
+
 
 #################################
 ## Kube State configuration
@@ -185,5 +155,3 @@ kubeState:
     requests:
       cpu: "0m"
       memory: "0Mi"
-    limits:
-      cpu: "100m"

--- a/configs/local-dev.yaml
+++ b/configs/local-dev.yaml
@@ -21,7 +21,8 @@ global:
 
 ############################
 ## Astronomer configuration
-## Omit resouce requests
+## Configure resouce requests
+## as small as possible
 ############################
 
 astronomer:
@@ -30,11 +31,15 @@ astronomer:
       requests:
         cpu: "0m"
         memory: "0Mi"
+    limits:
+      cpu: "100m"
   houston:
     resources:
       requests:
         cpu: "0m"
         memory: "0Mi"
+      limits:
+        cpu: "500m"
 
     config:
       auth:
@@ -50,6 +55,8 @@ astronomer:
       requests:
         cpu: "0m"
         memory: "0Mi"
+      limits:
+        cpu: "100m"
   registry:
     resources:
       requests:
@@ -69,10 +76,10 @@ nginx:
   # Configure resources
   resources:
     requests:
-      cpu: "500m"
-      memory: "1024Mi"
+      cpu: "0m"
+      memory: "0Mi"
     limits:
-      cpu: "1"
+      cpu: "100m"
       memory: "2048Mi"
 
 #################################
@@ -84,6 +91,8 @@ grafana:
     requests:
       cpu: "0m"
       memory: "0Mi"
+    limits:
+      cpu: "100m"
 
 #################################
 ## Prometheus configuration
@@ -94,6 +103,9 @@ prometheus:
     requests:
       cpu: "0m"
       memory: "0Gi"
+    limits:
+      cpu: "100m"
+      memory: "2Gi"
 
 #################################
 ## Elasticsearch configuration
@@ -103,26 +115,41 @@ elasticsearch:
   client:
     replicas: 1
     resources:
+      heapMemory: 256
       requests:
         cpu: "0"
-        memory: "0Gi"
+        memory: "256Mi"
 
   # Configure data nodes
   data:
     replicas: 1
     resources:
+      heapMemory: 128
       requests:
         cpu: "0"
-        memory: "0"
+        memory: "128Mi"
+      limits:
+        cpu: "100m"
+    persistence:
+      size: 1Gi
 
   # Configure master nodes
   master:
     replicas: 1
     resources:
+      heapMemory: 128
       requests:
         cpu: "0"
-        memory: "0Gi"
+        memory: "128Mi"
+      limits:
+        cpu: "100m"
+    env:
+      NUMBER_OF_MASTERS: "1"
+    persistence:
+      size: 1Gi
 
+  curator:
+    enabled: false
 
 #################################
 ## Kibana configuration
@@ -133,6 +160,8 @@ kibana:
     requests:
       cpu: "0m"
       memory: "0Mi"
+    limits:
+      cpu: "100m"
 
 
 #################################
@@ -144,7 +173,8 @@ fluentd:
     requests:
       cpu: "0m"
       memory: "0Mi"
-
+    limits:
+      cpu: "100m"
 
 #################################
 ## Kube State configuration
@@ -155,3 +185,5 @@ kubeState:
     requests:
       cpu: "0m"
       memory: "0Mi"
+    limits:
+      cpu: "100m"


### PR DESCRIPTION
I noticed one bug in my CI script that causes the timeout to not work, and it's fixed in this PR.

Also, I enabled installing the monitoring and kubed chart tags in CI. This is useful for making sure alertmanager and prometheus have a valid configuration.

I was unsuccessful today in getting logging to install in CI. Next week I will proceed on to the individual components' pipelines.