### PR TITLE
Cap connections from prisma to houston DB to 5

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 name: astronomer-platform
-version: 0.10.3-fix.4
+version: 0.10.3-fix.5
 appVersion: 0.10.3
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg

--- a/charts/astronomer/templates/prisma/prisma-configmap.yaml
+++ b/charts/astronomer/templates/prisma/prisma-configmap.yaml
@@ -20,3 +20,9 @@ data:
         connector: postgres
         uri: $PRISMA_DB_URI
         migrations: true
+        # 2 is the minimum allowed value
+        # There is one connection reserved
+        # for management operations, so the queries
+        # can make use of one less than the configured
+        # number here.
+        connectionLimit: 5


### PR DESCRIPTION
This is not to be merged, only to be referenced for the diff b/w fix.4 and fix.5

https://www.prisma.io/docs/1.25/prisma-server/database-connector-POSTGRES-jgfr/#overview

mitigation attempt for https://github.com/astronomer/issues/issues/630

Upstream PR https://github.com/astronomer/helm.astronomer.io/pull/259