### PR TITLE
Reduce load by removing a heavy metric

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -165,6 +165,7 @@ data:
             target_label: release
 
       - job_name: fluentd
+        scrape_interval: 30s
         kubernetes_sd_configs:
           - role: pod
             namespaces:
@@ -182,6 +183,9 @@ data:
             regex: ([^:]+)(?::\d+)?;(\d+)
             replacement: $1:$2
             target_label: __address__
+          - source_labels: [__name__]
+            regex: 'fluentd_tail_file_.*'
+            action: drop
 
       - job_name: airflow
         scrape_interval: 5s


### PR DESCRIPTION
These metrics track for all log files:

fluentd_tail_file_position
- Current bytes which plugin reads from the file

fluentd_tail_file_inode
- inode of the file

https://github.com/fluent/fluent-plugin-prometheus