### PR TITLE
Increase KubeD CPU limit

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -304,5 +304,5 @@ kubed:
       cpu: "250m"
       memory: "512Mi"
     limits:
-      cpu: "500m"
+      cpu: "2"
       memory: "1024Mi"


### PR DESCRIPTION
Set on prod. It feels like a config that would be good to add to the helm chart defaults.